### PR TITLE
Update TECHNICAL-STEERING-COMMITTEE.md

### DIFF
--- a/TECHNICAL-STEERING-COMMITTEE.md
+++ b/TECHNICAL-STEERING-COMMITTEE.md
@@ -1,1 +1,1 @@
-TSC members will be listed here. initially, it will have to be manually maintained
+The Technical Steering Committee (TSC) is made up of members from the community who are chosen based on merit and confirmed by the Project Governing Board. The TSC directs the day-to-day technical activities of the project. If you are interested in serving on the TSC, contact project-admin@oasis-open.org.


### PR DESCRIPTION
TSC members usually won't be in place when the Github site is launched (since they need to be approved by the PGB and the PGB may not convene until after launch). I think generic text like this will be better than a "Coming soon" message. We may want to instruct people interested in serving on the TSC to contact the PGB and not staff, though.